### PR TITLE
Add spellcheck to CI jobs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,14 @@
+name: Spellcheck Action
+on: push
+
+jobs:
+  build:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+    # The checkout step
+    - uses: actions/checkout@v3
+    - uses: rojopolis/spellcheck-github-actions@0.33.1
+      name: Spellcheck
+      with:
+        config_path: ./.spellcheck.yml

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -1,0 +1,16 @@
+matrix:
+- name: Markdown
+  aspell:
+    lang: en
+  dictionary:
+    encoding: utf-8
+  pipeline:
+  - pyspelling.filters.markdown:
+  - pyspelling.filters.html:
+      comments: false
+      ignores:
+      - code
+      - pre
+  sources:
+  - '**/*.md'
+  default_encoding: utf-8

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -3,9 +3,13 @@ matrix:
   aspell:
     lang: en
   dictionary:
+    wordlists:
+    - .wordlist.txt
     encoding: utf-8
   pipeline:
   - pyspelling.filters.markdown:
+      markdown_extensions:
+      - pymdownx.superfences
   - pyspelling.filters.html:
       comments: false
       ignores:

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,0 +1,11 @@
+README
+repo
+yaml
+github
+https
+io
+url
+Bundler
+workflow
+param
+Github

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You might want to maintain your docs in an existing project repo. Instead of cre
 
 2.  Create a `docs` directory at your project root and copy all remaining template files into this directory.
 
-### Modify the Github Actions worklow
+### Modify the Github Actions workflow
 
 The Github Actions workflow that builds and deploys your site to Github Pages is defined by the `pages.yml` file. You'll need to edit this file to that so that your build and deploy steps look to your `docs` directory, rather than the project root.
 


### PR DESCRIPTION
Adds a baseline for spelling on all Markdown files and documentation.

Currently the job runs on all branches but can be modified to only run against a PR to `main`.