### PR TITLE
Fix non-reachable documentation

### DIFF
--- a/docs/games/minecraft/config-forge.md
+++ b/docs/games/minecraft/config-forge.md
@@ -2,6 +2,7 @@
 title: Configuring a Minecraft Forge Server
 layout: default
 parent: Minecraft
+grand_parent: Games
 nav_order: 1
 ---
 


### PR DESCRIPTION
This documentation page was not accessible unless the full path was specified in the URL, this is now fixed.